### PR TITLE
Causes python-pip system package to be installed, and pip package prometheus_client.

### DIFF
--- a/init/initialize.sh
+++ b/init/initialize.sh
@@ -15,14 +15,16 @@ $SLICEHOME/init/stop.sh     || true
 killall /usr/bin/python     || true
 killall /usr/sbin/tcpdump   || true
 
-echo "Install httpd and perform System Update"
+echo "Install required packages and perform System Update"
 # echo "Check/Install system tools"
 [ -f $SLICEHOME/.yumdone2 ] || \
     (
         rm -f $SLICEHOME/.yumdone*
         yum install -y httpd gnuplot-py gnuplot
         yum install -y paris-traceroute
+        yum install -y python-pip
         touch $SLICEHOME/.yumdone2
+        pip install prometheus_client
     )
 # make sure that everything is up to date
 yum update -y


### PR DESCRIPTION
While @gfr10598 was updating sidestream he also added functionality for sidestream to export data in a prometheus-friendly format. This functionality requires the python package `prometheus_client` which is not available as a system package.  This PR first install the `python-pip` system package, and then uses pip to install the python package `prometheus_client`.