### PR TITLE
Updates stop.sh to kill paris_rollins.py processes.

### DIFF
--- a/init/start.sh
+++ b/init/start.sh
@@ -18,6 +18,7 @@ if [ -f $PIDFILE ]; then
 		exit 1
 	fi
 fi
+service httpd start
 ${DIAG_SERVER_DAEMON} ${DIAG_SERVER_OPTS}
 echo "NPAD server started."
 $SLICEHOME/build/redisplay.py -daemon $SLICEHOME/VAR/www/ServerData $RSYNCDIR_NPAD $MYNODE &

--- a/init/stop.sh
+++ b/init/stop.sh
@@ -12,8 +12,10 @@ DIAG_SERVER_OPTS="-d -u $USER -p $PIDFILE"
 if [ -f $PIDFILE ]; then
 	killall redisplay.py || :
 	killall exitstats.py || :
+	killall paris_rollins.py || :
 	killall tcpdump || : 	
 	killall -9 tdump8000.py || : 	# does not respect sigterm
+	service httpd stop
 	pid=`cat $PIDFILE`
 	if [ "`ps -p $pid -o comm=`" = "DiagServer.py" ]; then
 		kill $pid


### PR DESCRIPTION
In addition to killing paris_rollins.py when stopped, this PR also starts and stops the httpd service in start.sh and stop.sh, respectively. On a clean boot up of an iupui_npad sliver httpd will be running anyway because the httpd service is configured to start on boot in initialize.sh, so adding `service httpd start` to start.sh is slightly redundant. However, it is good to have in there in case someone is manually starting/stopping httpd in the sliver, and because start.sh should probably be explicit about a hard dependency.

Stopping the httpd service in stop.sh seems good because it seems like when a sliver is stopped, all dependent processes should stop, and the sliver should be quiescent except for critical processes like crond and rsyncd, and not having httpd continue to server up NPAD web pages with links that will break because the underlying DiagServer isn't running.