### PR TITLE
Run yum update and package installs unconditionally

### DIFF
--- a/init/initialize.sh
+++ b/init/initialize.sh
@@ -16,16 +16,11 @@ killall /usr/bin/python     || true
 killall /usr/sbin/tcpdump   || true
 
 echo "Install required packages and perform System Update"
-# echo "Check/Install system tools"
-[ -f $SLICEHOME/.yumdone2 ] || \
-    (
-        rm -f $SLICEHOME/.yumdone*
-        yum install -y httpd gnuplot-py gnuplot
-        yum install -y paris-traceroute
-        yum install -y python-pip
-        touch $SLICEHOME/.yumdone2
-        pip install prometheus_client
-    )
+yum install -y httpd gnuplot-py gnuplot
+yum install -y paris-traceroute
+yum install -y python-pip
+pip install prometheus_client
+
 # make sure that everything is up to date
 yum update -y
 


### PR DESCRIPTION
This change removes the conditional execution of package install commands. The presence of `$SLICEHOME/.yumdone2` was causing new versions of the npad slice to fail to install dependencies for SideStream.

This change is considered safe because:

 * `initialize.sh` only runs during package install or reinstall.
 * yum and pip install commands are idempotent.
 * there are no other users of the `$SLICEHOME/.yumdone2` file.

The use of `.yumdone2` appears to have been an optimization with unintended interactions with the slice-canary process.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/npad-support/20)
<!-- Reviewable:end -->
