### PR TITLE
Explicitly install the libtool package to provide libtoolize.

### DIFF
--- a/init/prepare.sh
+++ b/init/prepare.sh
@@ -18,6 +18,8 @@ fi
 
 # SETUP development environment
 yum groupinstall -y 'Development Tools'
+# Libtool provides libtoolize needed for web100 autogen.sh.
+yum install -y libtool
 if ! rpm -q gtk2-devel &> /dev/null ; then
     # while we do not link to these libraries they are 
     # needed for 'autogen.sh' to work correctly.


### PR DESCRIPTION
This PR addresses a build issue observed in: https://github.com/m-lab/npad-support/pull/34

It seems that libtool is not automatically installed as part of the 'Development Tools' groupinstall.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/npad-support/35)
<!-- Reviewable:end -->
