### PR TITLE
Install which

### DIFF
--- a/init/prepare.sh
+++ b/init/prepare.sh
@@ -18,8 +18,8 @@ fi
 
 # SETUP development environment
 yum groupinstall -y 'Development Tools'
-# Libtool provides libtoolize needed for web100 autogen.sh.
-yum install -y libtool
+# The web100 autogen.sh requires which.
+yum install -y which
 if ! rpm -q gtk2-devel &> /dev/null ; then
     # while we do not link to these libraries they are 
     # needed for 'autogen.sh' to work correctly.


### PR DESCRIPTION
https://github.com/m-lab/npad-support/pull/35 was incorrect libtool is installed, but it seems that `which` is unavailable in the base docker image and autogen.sh redirects stderr to `/dev/null` masking the command not found error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/npad-support/36)
<!-- Reviewable:end -->
