### PR TITLE
Use custom paris traceroute

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,7 @@
 [submodule "travis"]
 	path = travis
 	url = https://github.com/m-lab/travis.git
+[submodule "libparistraceroute"]
+	path = libparistraceroute
+	url = https://github.com/libparistraceroute/libparistraceroute.git
+	branch = master2

--- a/init/initialize.sh
+++ b/init/initialize.sh
@@ -17,7 +17,8 @@ killall /usr/sbin/tcpdump   || true
 
 echo "Install required packages and perform System Update"
 yum install -y httpd gnuplot-py gnuplot
-yum install -y paris-traceroute
+# Commented out until fix for overlapping PT bug is in upstream .rpm
+# yum install -y paris-traceroute
 yum install -y python-pip
 pip install prometheus_client
 

--- a/init/prepare.sh
+++ b/init/prepare.sh
@@ -50,7 +50,7 @@ popd
 # Required because fix for overlapping PT bug is too new to be in upstream RPMs.
 # This code shouldbe deleted when the bugfix migrates outwards.
 pushd $SOURCE_DIR/libparistraceroute
-    ./augen.sh
+    ./autogen.sh
     ./configure
     make
     make install

--- a/init/prepare.sh
+++ b/init/prepare.sh
@@ -45,7 +45,17 @@ pushd $SOURCE_DIR/npad
     make
     make install
 popd
- 
+
+# build paris-traceroute
+# Required because fix for overlapping PT bug is too new to be in upstream RPMs.
+# This code shouldbe deleted when the bugfix migrates outwards.
+pushd $SOURCE_DIR/libparistraceroute
+    ./augen.sh
+    ./configure
+    make
+    make install
+popd
+
 # install init scripts
 cp -r $SOURCE_DIR/init $BUILD_DIR/
 


### PR DESCRIPTION
This builds a custom paris traceroute instead of installing it from upstream .rpms.  I don't have a good way of testing this code, so if either of you could recommend a method, I am all ears.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/npad-support/44)
<!-- Reviewable:end -->
