### PR TITLE
Install new paris-traceroute bin where rollins wants it

### DIFF
--- a/init/initialize.sh
+++ b/init/initialize.sh
@@ -17,9 +17,8 @@ killall /usr/sbin/tcpdump   || true
 
 echo "Install required packages and perform System Update"
 yum install -y httpd gnuplot-py gnuplot
-# Commented out until fix for overlapping PT bug is in upstream .rpm
-# TODO: remove comment once bug fix is deployed to upstream
-# yum install -y paris-traceroute
+# Copy paris-traceroute binary to the location expected by paris_rollins.py
+cp -a $SLICEHOME/build/bin/paris-traceroute /usr/local/bin/
 yum install -y python-pip
 pip install prometheus_client
 


### PR DESCRIPTION
This fixes a bug found on the paris traceroute canary.

Essentially the old binary was not uninstalled and the new path was not used by paris_rollins.py. To fix this we copy the new binary to the location expected by paris_rollins.py.

FYI: @pboothe @nkinkade

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/npad-support/47)
<!-- Reviewable:end -->
